### PR TITLE
fix/401Logging

### DIFF
--- a/lib/fetchSaga.js
+++ b/lib/fetchSaga.js
@@ -141,61 +141,53 @@ function fetchData(action) {
 
 				case 24:
 					_context.prev = 24;
+					_context.next = 27;
+					return (0, _effects.call)(tokenAccessFunction, action.modelName);
 
-					if (action.noAuth) {
-						_context.next = 30;
-						break;
-					}
-
-					_context.next = 28;
-					return (0, _effects.call)(tokenAccessFunction);
-
-				case 28:
+				case 27:
 					oauthToken = _context.sent;
 
 					if (oauthToken && oauthToken.access_token) {
 						fetchConfig.headers['Authorization'] = 'Bearer ' + oauthToken.access_token;
 					}
-
-				case 30:
-					_context.next = 32;
+					_context.next = 31;
 					return (0, _effects.race)({
 						fetchResult: (0, _effects.call)(_fetchService.doFetch, fetchConfig),
 						timedOut: (0, _effects.call)(_reduxSaga.delay, action.timeLimit ? action.timeLimit : 30000)
 					});
 
-				case 32:
+				case 31:
 					_ref = _context.sent;
 					fetchResult = _ref.fetchResult;
 					timedOut = _ref.timedOut;
 
 					if (!(fetchResult && !(fetchResult.title && fetchResult.title === 'Error'))) {
-						_context.next = 40;
+						_context.next = 39;
 						break;
 					}
 
-					_context.next = 38;
+					_context.next = 37;
 					return (0, _effects.put)((0, _actions.createAction)(action.noStore ? _actions2.default.TRANSIENT_FETCH_RESULT_RECEIVED : _actions2.default.FETCH_RESULT_RECEIVED, {
 						data: fetchResult,
 						modelName: action.modelName
 					}));
 
-				case 38:
-					_context.next = 52;
+				case 37:
+					_context.next = 51;
 					break;
 
-				case 40:
+				case 39:
 					if (!timedOut) {
-						_context.next = 48;
+						_context.next = 47;
 						break;
 					}
 
-					_context.next = 43;
+					_context.next = 42;
 					return (0, _effects.put)((0, _actions.createAction)(_actions2.default.FETCH_TIMED_OUT, {
 						modelName: action.modelName
 					}));
 
-				case 43:
+				case 42:
 					didTimeOut = true;
 					errorObject = {
 						type: _actions2.default.FETCH_TIMED_OUT,
@@ -204,14 +196,14 @@ function fetchData(action) {
 					};
 					throw new Error(JSON.stringify(errorObject));
 
-				case 48:
-					_context.next = 50;
+				case 47:
+					_context.next = 49;
 					return (0, _effects.put)((0, _actions.createAction)(_actions2.default.FETCH_TRY_FAILED, {
 						modelName: action.modelName,
 						errorData: fetchResult
 					}));
 
-				case 50:
+				case 49:
 					_errorObject = {
 						type: _actions2.default.FETCH_TRY_FAILED,
 						modelName: action.modelName,
@@ -219,17 +211,12 @@ function fetchData(action) {
 					};
 					throw new Error(JSON.stringify(_errorObject));
 
-<<<<<<< HEAD
-				case 49:
-					_context.next = 62;
-=======
-				case 52:
-					_context.next = 63;
->>>>>>> develop
+				case 51:
+					_context.next = 64;
 					break;
 
-				case 54:
-					_context.prev = 54;
+				case 53:
+					_context.prev = 53;
 					_context.t0 = _context['catch'](24);
 					_errorObject2 = JSON.parse(_context.t0.message);
 					_fetchResult = _errorObject2.errorData;
@@ -244,67 +231,39 @@ function fetchData(action) {
 					lastError = _context.t0;
 					logger('fetchData fail');
 					logger(_context.t0);
-<<<<<<< HEAD
-					_context.next = 62;
+					_context.next = 64;
 					return (0, _effects.call)(_reduxSaga.delay, 2 ^ tryCount * 100);
 
-				case 62:
-=======
-					_context.next = 63;
-					return (0, _effects.call)(_reduxSaga.delay, 2 ^ tryCount * 100);
-
-				case 63:
->>>>>>> develop
+				case 64:
 					if (tryCount < tryLimit && didFail) {
 						_context.next = 19;
 						break;
 					}
 
-<<<<<<< HEAD
-				case 63:
+				case 65:
 					if (!(tryCount === tryLimit && didFail)) {
-						_context.next = 69;
-=======
-				case 64:
-					if (!(tryCount === tryLimit && didFail)) {
-						_context.next = 70;
->>>>>>> develop
+						_context.next = 71;
 						break;
 					}
 
 					if (didTimeOut) {
-<<<<<<< HEAD
-						_context.next = 67;
+						_context.next = 69;
 						break;
 					}
 
-					_context.next = 67;
+					_context.next = 69;
 					return (0, _effects.put)((0, _actions.createAction)(_actions2.default.FETCH_FAILED, { modelName: action.modelName }));
-
-				case 67:
-					logger('fetchData retry fail');
-					logger(lastError);
 
 				case 69:
-=======
-						_context.next = 68;
-						break;
-					}
-
-					_context.next = 68;
-					return (0, _effects.put)((0, _actions.createAction)(_actions2.default.FETCH_FAILED, { modelName: action.modelName }));
-
-				case 68:
 					logger('fetchData retry fail');
 					logger(lastError);
 
-				case 70:
->>>>>>> develop
+				case 71:
 				case 'end':
 					return _context.stop();
 			}
 		}
-	}, _marked[0], this, [[24, 54]]);
+	}, _marked[0], this, [[24, 53]]);
 }
 
 /**

--- a/lib/fetchSaga.js
+++ b/lib/fetchSaga.js
@@ -208,7 +208,7 @@ function fetchData(action) {
 					throw new Error(JSON.stringify(_errorObject));
 
 				case 49:
-					_context.next = 63;
+					_context.next = 62;
 					break;
 
 				case 51:
@@ -217,9 +217,8 @@ function fetchData(action) {
 					_errorObject2 = JSON.parse(_context.t0.message);
 					_fetchResult = _errorObject2.errorData;
 
-					console.log('error is ' + _context.t0.message);
+					// Don't do anything with 401 errors
 
-					// Don't log 401 errors
 					if (errorFunction && _fetchResult.code != 401) {
 						errorFunction(_context.t0.message);
 					}
@@ -227,34 +226,34 @@ function fetchData(action) {
 					lastError = _context.t0;
 					logger('fetchData fail');
 					logger(_context.t0);
-					_context.next = 63;
+					_context.next = 62;
 					return (0, _effects.call)(_reduxSaga.delay, 2 ^ tryCount * 100);
 
-				case 63:
+				case 62:
 					if (tryCount < tryLimit && didFail) {
 						_context.next = 19;
 						break;
 					}
 
-				case 64:
+				case 63:
 					if (!(tryCount === tryLimit && didFail)) {
-						_context.next = 70;
+						_context.next = 69;
 						break;
 					}
 
 					if (didTimeOut) {
-						_context.next = 68;
+						_context.next = 67;
 						break;
 					}
 
-					_context.next = 68;
+					_context.next = 67;
 					return (0, _effects.put)((0, _actions.createAction)(_actions2.default.FETCH_FAILED, { modelName: action.modelName }));
 
-				case 68:
+				case 67:
 					logger('fetchData retry fail');
 					logger(lastError);
 
-				case 70:
+				case 69:
 				case 'end':
 					return _context.stop();
 			}

--- a/lib/fetchSaga.js
+++ b/lib/fetchSaga.js
@@ -187,7 +187,8 @@ function fetchData(action) {
 					didTimeOut = true;
 					errorObject = {
 						type: _actions2.default.FETCH_TIMED_OUT,
-						modelName: action.modelName
+						modelName: action.modelName,
+						errorData: fetchResult
 					};
 					throw new Error(JSON.stringify(errorObject));
 

--- a/lib/fetchSaga.js
+++ b/lib/fetchSaga.js
@@ -218,8 +218,9 @@ function fetchData(action) {
 					_fetchResult = _errorObject2.errorData;
 
 					// Don't do anything with 401 errors
+					// And some errors don't have fetch results associated with them
 
-					if (errorFunction && _fetchResult.code != 401) {
+					if (errorFunction && (_fetchResult ? _fetchResult.code != 401 : true)) {
 						errorFunction(_context.t0.message);
 					}
 					didFail = true;

--- a/lib/fetchSaga.js
+++ b/lib/fetchSaga.js
@@ -55,7 +55,7 @@ var errorFunction = void 0;
  * @param {FetchAction} action - An action with the request configuration
  */
 function fetchData(action) {
-	var baseConfig, headers, fetchConfig, store, tryLimit, tryCount, didFail, didTimeOut, lastError, oauthToken, _ref, fetchResult, timedOut, errorObject, _errorObject;
+	var baseConfig, headers, fetchConfig, store, tryLimit, tryCount, didFail, didTimeOut, lastError, oauthToken, _ref, fetchResult, timedOut, errorObject, _errorObject, _errorObject2, _fetchResult;
 
 	return _regenerator2.default.wrap(function fetchData$(_context) {
 		while (1) {
@@ -207,48 +207,53 @@ function fetchData(action) {
 					throw new Error(JSON.stringify(_errorObject));
 
 				case 49:
-					_context.next = 60;
+					_context.next = 63;
 					break;
 
 				case 51:
 					_context.prev = 51;
 					_context.t0 = _context['catch'](24);
+					_errorObject2 = JSON.parse(_context.t0.message);
+					_fetchResult = _errorObject2.errorData;
 
-					if (errorFunction) {
+					console.log('error is ' + _context.t0.message);
+
+					// Don't log 401 errors
+					if (errorFunction && _fetchResult.code != 401) {
 						errorFunction(_context.t0.message);
 					}
 					didFail = true;
 					lastError = _context.t0;
 					logger('fetchData fail');
 					logger(_context.t0);
-					_context.next = 60;
+					_context.next = 63;
 					return (0, _effects.call)(_reduxSaga.delay, 2 ^ tryCount * 100);
 
-				case 60:
+				case 63:
 					if (tryCount < tryLimit && didFail) {
 						_context.next = 19;
 						break;
 					}
 
-				case 61:
+				case 64:
 					if (!(tryCount === tryLimit && didFail)) {
-						_context.next = 67;
+						_context.next = 70;
 						break;
 					}
 
 					if (didTimeOut) {
-						_context.next = 65;
+						_context.next = 68;
 						break;
 					}
 
-					_context.next = 65;
+					_context.next = 68;
 					return (0, _effects.put)((0, _actions.createAction)(_actions2.default.FETCH_FAILED, { modelName: action.modelName }));
 
-				case 65:
+				case 68:
 					logger('fetchData retry fail');
 					logger(lastError);
 
-				case 67:
+				case 70:
 				case 'end':
 					return _context.stop();
 			}
@@ -427,6 +432,7 @@ var tokenAccess = function tokenAccess() {
  * @export
  * @param {Object} modelsParam - An object indicating the APIs available in a application with which to make requests
  * @param {string} apiRootParam - A url to which partial URLs are appended (i.e.) 'https://myapp.com'
+ * @param {TokenAccessFunction} [tokenAccessParam=tokenAccess] - function that returns an optional OAuth token
  * @param {ErrorFunction} errorParam  - A function to perform on errors
  * @param {LoggerFunction} [loggerParam=consoleLogger] - A function that accepts a string and logs it real good
  */

--- a/src/fetchSaga.js
+++ b/src/fetchSaga.js
@@ -152,7 +152,8 @@ function* fetchData(action: FetchAction) {
 					didTimeOut = true
 					let errorObject = {
 						type: actions.FETCH_TIMED_OUT,
-						modelName: action.modelName
+						modelName: action.modelName,
+						errorData: fetchResult
 					}
 					throw new Error(JSON.stringify(errorObject))
 				} else {

--- a/src/fetchSaga.js
+++ b/src/fetchSaga.js
@@ -174,9 +174,8 @@ function* fetchData(action: FetchAction) {
 		} catch (error) {
 			let errorObject = JSON.parse(error.message)
 			let fetchResult = errorObject.errorData
-			console.log('error is ' + error.message)
 
-			// Don't log 401 errors
+			// Don't do anything with 401 errors
 			if (errorFunction && fetchResult.code != 401) {
 				errorFunction(error.message)
 			}

--- a/src/fetchSaga.js
+++ b/src/fetchSaga.js
@@ -171,7 +171,12 @@ function* fetchData(action: FetchAction) {
 				}
 			}
 		} catch (error) {
-			if (errorFunction) {
+			let errorObject = JSON.parse(error.message)
+			let fetchResult = errorObject.errorData
+			console.log('error is ' + error.message)
+
+			// Don't log 401 errors
+			if (errorFunction && fetchResult.code != 401) {
 				errorFunction(error.message)
 			}
 			didFail = true

--- a/src/fetchSaga.js
+++ b/src/fetchSaga.js
@@ -176,7 +176,8 @@ function* fetchData(action: FetchAction) {
 			let fetchResult = errorObject.errorData
 
 			// Don't do anything with 401 errors
-			if (errorFunction && fetchResult.code != 401) {
+			// And some errors don't have fetch results associated with them
+			if (errorFunction && (fetchResult ? fetchResult.code != 401 : true)) {
 				errorFunction(error.message)
 			}
 			didFail = true


### PR DESCRIPTION
Don't call `errorFunction` on 401 errors, which in our case, was being used to log to Sentry