### PR TITLE
Improved Error Handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "studiokit-net-js",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"scripts": {
 		"eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
 		"lint": "eslint --ext=js ./*.js src test",

--- a/src/fetchReducer.js
+++ b/src/fetchReducer.js
@@ -8,9 +8,18 @@ import type { Action } from 'redux'
 
 type FetchState = {}
 
+type FetchError = {
+	modelName: string,
+	errorData: {
+		didTimeOut: boolean,
+		fetchResult: any
+	}
+}
+
 type MetadataState = {
 	isFetching: boolean,
 	hasError: boolean,
+	lastFetchError: FetchError,
 	timedOut: boolean,
 	fetchedAt?: Date
 }
@@ -47,6 +56,7 @@ export default function fetchReducer(state: FetchState = {}, action: Action) {
 			newValue._metadata = _.merge(metadata, {
 				isFetching: true,
 				hasError: false,
+				lastFetchError: undefined,
 				timedOut: false
 			})
 			return _fp.set(path, newValue, state)
@@ -56,6 +66,7 @@ export default function fetchReducer(state: FetchState = {}, action: Action) {
 			newValue._metadata = _.merge(metadata, {
 				isFetching: false,
 				hasError: false,
+				lastFetchError: undefined,
 				timedOut: false,
 				fetchedAt: new Date()
 			})
@@ -65,6 +76,7 @@ export default function fetchReducer(state: FetchState = {}, action: Action) {
 			newValue._metadata = _.merge(metadata, {
 				isFetching: false,
 				hasError: true,
+				lastFetchError: action.lastFetchError,
 				timedOut: !!action.didTimeOut
 			})
 			return _fp.set(path, newValue, state)

--- a/src/fetchReducer.js
+++ b/src/fetchReducer.js
@@ -12,8 +12,7 @@ type FetchError = {
 	modelName: string,
 	errorData: {
 		didTimeOut: boolean
-	},
-	fetchResult: any
+	}
 }
 
 type MetadataState = {

--- a/src/fetchReducer.js
+++ b/src/fetchReducer.js
@@ -11,9 +11,9 @@ type FetchState = {}
 type FetchError = {
 	modelName: string,
 	errorData: {
-		didTimeOut: boolean,
-		fetchResult: any
-	}
+		didTimeOut: boolean
+	},
+	fetchResult: any
 }
 
 type MetadataState = {

--- a/src/fetchSaga.js
+++ b/src/fetchSaga.js
@@ -284,7 +284,11 @@ function* fetchData(action: FetchAction) {
 				fetchResult: call(doFetch, fetchConfig),
 				timedOutResult: call(delay, action.timeLimit ? action.timeLimit : 30000)
 			})
-			if (fetchResult && !(fetchResult.title && fetchResult.title === 'Error')) {
+			if (
+				fetchResult &&
+				!(fetchResult.title && fetchResult.title === 'Error') &&
+				!(fetchResult.code && fetchResult.code >= 400)
+			) {
 				let storeAction = action.noStore
 					? actions.TRANSIENT_FETCH_RESULT_RECEIVED
 					: actions.FETCH_RESULT_RECEIVED

--- a/test/fetchReducer.spec.js
+++ b/test/fetchReducer.spec.js
@@ -11,14 +11,30 @@ describe('fetchReducer', () => {
 		test('single level', () => {
 			const state = fetchReducer({}, { type: actions.FETCH_REQUESTED, modelName: 'test' })
 			expect(state).toEqual({
-				test: { _metadata: { isFetching: true, hasError: false, timedOut: false } }
+				test: {
+					_metadata: {
+						isFetching: true,
+						hasError: false,
+						lastFetchError: undefined,
+						timedOut: false
+					}
+				}
 			})
 		})
 
 		test('nested level', () => {
 			const state = fetchReducer({}, { type: actions.FETCH_REQUESTED, modelName: 'user.test' })
 			expect(state).toEqual({
-				user: { test: { _metadata: { isFetching: true, hasError: false, timedOut: false } } }
+				user: {
+					test: {
+						_metadata: {
+							isFetching: true,
+							hasError: false,
+							lastFetchError: undefined,
+							timedOut: false
+						}
+					}
+				}
 			})
 		})
 
@@ -29,7 +45,16 @@ describe('fetchReducer', () => {
 			)
 			expect(state).toEqual({
 				foo: 'bar',
-				user: { test: { _metadata: { isFetching: true, hasError: false, timedOut: false } } }
+				user: {
+					test: {
+						_metadata: {
+							isFetching: true,
+							hasError: false,
+							lastFetchError: undefined,
+							timedOut: false
+						}
+					}
+				}
 			})
 		})
 
@@ -41,7 +66,14 @@ describe('fetchReducer', () => {
 			expect(state).toEqual({
 				user: {
 					foo: 'bar',
-					test: { _metadata: { isFetching: true, hasError: false, timedOut: false } }
+					test: {
+						_metadata: {
+							isFetching: true,
+							hasError: false,
+							lastFetchError: undefined,
+							timedOut: false
+						}
+					}
 				}
 			})
 		})
@@ -306,10 +338,34 @@ describe('fetchReducer', () => {
 	})
 
 	describe('FETCH_FAILED', () => {
-		test('single level', () => {
+		test('single level with fetch error data', () => {
+			const state = fetchReducer(
+				{},
+				{ type: actions.FETCH_FAILED, modelName: 'test', lastFetchError: 'server fire' }
+			)
+			expect(state).toEqual({
+				test: {
+					_metadata: {
+						isFetching: false,
+						hasError: true,
+						lastFetchError: 'server fire',
+						timedOut: false
+					}
+				}
+			})
+		})
+
+		test('single level no fetch error data', () => {
 			const state = fetchReducer({}, { type: actions.FETCH_FAILED, modelName: 'test' })
 			expect(state).toEqual({
-				test: { _metadata: { isFetching: false, hasError: true, timedOut: false } }
+				test: {
+					_metadata: {
+						isFetching: false,
+						hasError: true,
+						lastFetchError: undefined,
+						timedOut: false
+					}
+				}
 			})
 		})
 
@@ -324,32 +380,60 @@ describe('fetchReducer', () => {
 		})
 
 		test('nested level', () => {
-			const state = fetchReducer({}, { type: actions.FETCH_FAILED, modelName: 'user.test' })
+			const state = fetchReducer(
+				{},
+				{ type: actions.FETCH_FAILED, modelName: 'user.test', lastFetchError: 'server fire' }
+			)
 			expect(state).toEqual({
-				user: { test: { _metadata: { isFetching: false, hasError: true, timedOut: false } } }
+				user: {
+					test: {
+						_metadata: {
+							isFetching: false,
+							hasError: true,
+							lastFetchError: 'server fire',
+							timedOut: false
+						}
+					}
+				}
 			})
 		})
 
 		test('nested level merge state', () => {
 			const state = fetchReducer(
 				{ foo: 'bar' },
-				{ type: actions.FETCH_FAILED, modelName: 'user.test' }
+				{ type: actions.FETCH_FAILED, modelName: 'user.test', lastFetchError: 'server fire' }
 			)
 			expect(state).toEqual({
 				foo: 'bar',
-				user: { test: { _metadata: { isFetching: false, hasError: true, timedOut: false } } }
+				user: {
+					test: {
+						_metadata: {
+							isFetching: false,
+							hasError: true,
+							lastFetchError: 'server fire',
+							timedOut: false
+						}
+					}
+				}
 			})
 		})
 
 		test('nested level replace state', () => {
 			const state = fetchReducer(
 				{ user: { foo: 'bar' } },
-				{ type: actions.FETCH_FAILED, modelName: 'user.test' }
+				{ type: actions.FETCH_FAILED, modelName: 'user.test', lastFetchError: 'server fire' }
 			)
 			expect(state).toEqual({
 				user: {
 					foo: 'bar',
-					test: { _metadata: { isFetching: false, hasError: true, timedOut: false } }
+					test: {
+						_metadata: {
+							isFetching: false,
+							hasError: true,
+							lastFetchError: 'server fire',
+							timedOut: false
+						}
+					}
 				}
 			})
 		})
@@ -373,7 +457,7 @@ describe('fetchReducer', () => {
 						}
 					}
 				},
-				{ type: actions.FETCH_FAILED, modelName: 'groups.1' }
+				{ type: actions.FETCH_FAILED, modelName: 'groups.1', lastFetchError: 'server fire' }
 			)
 			expect(state).toEqual({
 				groups: {
@@ -383,6 +467,7 @@ describe('fetchReducer', () => {
 						_metadata: {
 							isFetching: false,
 							hasError: true,
+							lastFetchError: 'server fire',
 							timedOut: false,
 							fetchedAt
 						}
@@ -424,7 +509,14 @@ describe('fetchReducer', () => {
 
 			const state2 = fetchReducer(state, { type: actions.FETCH_REQUESTED, modelName: 'test' })
 			expect(state2).toEqual({
-				test: { _metadata: { isFetching: true, hasError: false, timedOut: false } }
+				test: {
+					_metadata: {
+						isFetching: true,
+						hasError: false,
+						lastFetchError: undefined,
+						timedOut: false
+					}
+				}
 			})
 
 			const state3 = fetchReducer(state2, {
@@ -479,7 +571,14 @@ describe('fetchReducer', () => {
 		test('no state parameter passed', () => {
 			const state = fetchReducer(undefined, { type: actions.FETCH_REQUESTED, modelName: 'test' })
 			expect(state).toEqual({
-				test: { _metadata: { isFetching: true, hasError: false, timedOut: false } }
+				test: {
+					_metadata: {
+						isFetching: true,
+						hasError: false,
+						lastFetchError: undefined,
+						timedOut: false
+					}
+				}
 			})
 		})
 	})

--- a/test/fetchSaga.spec.js
+++ b/test/fetchSaga.spec.js
@@ -708,12 +708,25 @@ describe('fetchData', () => {
 			)
 		})
 
-		test('should retry on fetch error', () => {
+		test('should retry on fetch error title', () => {
 			const gen = fetchData({ modelName: 'test' })
 			const putFetchRequestEffect = gen.next()
 			const tokenAccessCall = gen.next()
 			const raceEffect = gen.next(getOauthToken())
 			const fetchTryFailedEffect = gen.next({ fetchResult: { title: 'Error' } })
+			const putTryFailedEffect = gen.next()
+			const delayAndPutAgainEffect = gen.next()
+			expect(delayAndPutAgainEffect.value).toEqual(
+				put(createAction(actions.FETCH_REQUESTED, { modelName: 'test' }))
+			)
+		})
+
+		test('should retry on fetch error code', () => {
+			const gen = fetchData({ modelName: 'test' })
+			const putFetchRequestEffect = gen.next()
+			const tokenAccessCall = gen.next()
+			const raceEffect = gen.next(getOauthToken())
+			const fetchTryFailedEffect = gen.next({ fetchResult: { code: 500 } })
 			const putTryFailedEffect = gen.next()
 			const delayAndPutAgainEffect = gen.next()
 			expect(delayAndPutAgainEffect.value).toEqual(


### PR DESCRIPTION
- Consider API responses with status code >= 400 to be errors
- Persist last fetch error into metadata in redux

@darrellshi This should take care of examining the reason for error and handling accordingly