### PR TITLE
hotfix/1.4.13

### DIFF
--- a/src/fetchSaga.js
+++ b/src/fetchSaga.js
@@ -295,18 +295,20 @@ function* fetchData(action: FetchAction) {
 					: actions.FETCH_RESULT_RECEIVED
 				let data = fetchResult.data
 				if (modelConfig.isCollection) {
-					data = {}
 					if (fetchConfig.method === 'DELETE') {
 						storeAction = actions.KEY_REMOVAL_REQUESTED
+						data = {}
 					} else if (isCollectionItemFetch || isCollectionItemCreate) {
 						data = fetchResult.data
 					} else {
 						const fetchedAt = new Date()
+						// convert to array if key-value object was returned for collection
 						const resultsArray = !_.isArray(fetchResult.data)
 							? Object.keys(fetchResult.data).map(key => fetchResult.data[key])
 							: fetchResult.data
-						resultsArray.forEach(item => {
-							data[item.id] = _.merge({}, item, {
+						// set metadata on each item
+						data = resultsArray.map(item => {
+							return _.merge({}, item, {
 								_metadata: {
 									isFetching: false,
 									hasError: false,

--- a/test/fetchReducer.spec.js
+++ b/test/fetchReducer.spec.js
@@ -5,7 +5,6 @@ import _ from 'lodash'
 const nonScalars = FetchReducerRewireAPI.__get__('nonScalars')
 const convertArraysToObjects = FetchReducerRewireAPI.__get__('convertArraysToObjects')
 const getMetadata = FetchReducerRewireAPI.__get__('getMetadata')
-const diff = FetchReducerRewireAPI.__get__('diff')
 
 describe('supporting functions', () => {
 	describe('nonScalars', () => {

--- a/test/fetchSaga.spec.js
+++ b/test/fetchSaga.spec.js
@@ -882,7 +882,7 @@ describe('fetchData', () => {
 
 	describe('collection fetch', () => {
 		describe('GET collection', () => {
-			test('should return a key-value object by id of nested items, from an api array', () => {
+			test('should not convert an api array to a key-value object', () => {
 				const fetchedAt = new Date()
 				const _Date = Date
 				global.Date = jest.fn(() => fetchedAt)
@@ -901,8 +901,8 @@ describe('fetchData', () => {
 				expect(resultReceivedEffect.value).toEqual(
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
-							data: {
-								1: {
+							data: [
+								{
 									id: 1,
 									name: 'foo',
 									_metadata: {
@@ -912,7 +912,7 @@ describe('fetchData', () => {
 										fetchedAt
 									}
 								},
-								2: {
+								{
 									id: 2,
 									name: 'bar',
 									_metadata: {
@@ -922,7 +922,7 @@ describe('fetchData', () => {
 										fetchedAt
 									}
 								}
-							},
+							],
 							modelName: 'entities'
 						})
 					)
@@ -930,7 +930,7 @@ describe('fetchData', () => {
 				expect(gen.next().done).toEqual(true)
 			})
 
-			test('should return a key-value object by id of nested items, from a key-value api object', () => {
+			test('should return an array from a key-value api object', () => {
 				const fetchedAt = new Date()
 				const _Date = Date
 				global.Date = jest.fn(() => fetchedAt)
@@ -949,8 +949,8 @@ describe('fetchData', () => {
 				expect(resultReceivedEffect.value).toEqual(
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
-							data: {
-								1: {
+							data: [
+								{
 									id: 1,
 									name: 'foo',
 									_metadata: {
@@ -960,7 +960,7 @@ describe('fetchData', () => {
 										fetchedAt
 									}
 								},
-								2: {
+								{
 									id: 2,
 									name: 'bar',
 									_metadata: {
@@ -970,7 +970,7 @@ describe('fetchData', () => {
 										fetchedAt
 									}
 								}
-							},
+							],
 							modelName: 'entities'
 						})
 					)
@@ -1225,7 +1225,7 @@ describe('fetchData', () => {
 
 	describe('nested collection fetch', () => {
 		describe('GET nested collection', () => {
-			test('should return a key-value object by id of nested items, from an api array', () => {
+			test('should not convert an api array to a key-value object', () => {
 				const fetchedAt = new Date()
 				const _Date = Date
 				global.Date = jest.fn(() => fetchedAt)
@@ -1247,8 +1247,8 @@ describe('fetchData', () => {
 				expect(resultReceivedEffect.value).toEqual(
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
-							data: {
-								1: {
+							data: [
+								{
 									id: 1,
 									name: 'foo',
 									_metadata: {
@@ -1258,7 +1258,7 @@ describe('fetchData', () => {
 										fetchedAt
 									}
 								},
-								2: {
+								{
 									id: 2,
 									name: 'bar',
 									_metadata: {
@@ -1268,7 +1268,7 @@ describe('fetchData', () => {
 										fetchedAt
 									}
 								}
-							},
+							],
 							modelName: 'topLevelEntities.1.secondLevelEntities'
 						})
 					)
@@ -1276,7 +1276,7 @@ describe('fetchData', () => {
 				expect(gen.next().done).toEqual(true)
 			})
 
-			test('should return a key-value object by id of nested items, from a key-value api object', () => {
+			test('should return an array, from a key-value api object', () => {
 				const fetchedAt = new Date()
 				const _Date = Date
 				global.Date = jest.fn(() => fetchedAt)
@@ -1298,8 +1298,8 @@ describe('fetchData', () => {
 				expect(resultReceivedEffect.value).toEqual(
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
-							data: {
-								1: {
+							data: [
+								{
 									id: 1,
 									name: 'foo',
 									_metadata: {
@@ -1309,7 +1309,7 @@ describe('fetchData', () => {
 										fetchedAt
 									}
 								},
-								2: {
+								{
 									id: 2,
 									name: 'bar',
 									_metadata: {
@@ -1319,7 +1319,7 @@ describe('fetchData', () => {
 										fetchedAt
 									}
 								}
-							},
+							],
 							modelName: 'topLevelEntities.1.secondLevelEntities'
 						})
 					)


### PR DESCRIPTION
* if model is a collection, e.g. a key-value object of things by id, remove existing items by key if they are not included in the new response
* update `convertArraysToObjects` to accept arrays as input, preserve non-id-object-having arrays
* do no do array to object conversion in `fetchSaga`