### PR TITLE
hotfix/1.4.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "studiokit-net-js",
-	"version": "1.4.17",
+	"version": "1.4.18",
 	"scripts": {
 		"eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
 		"lint": "eslint --ext=js ./*.js src test",

--- a/src/fetchSaga.js
+++ b/src/fetchSaga.js
@@ -284,6 +284,7 @@ function* fetchData(action: FetchAction) {
 		yield put(
 			createAction(action.noStore ? actions.TRANSIENT_FETCH_FAILED : actions.FETCH_FAILED, {
 				modelName: action.modelName,
+				guid: action.guid,
 				errorData: 'Invalid URL'
 			})
 		)
@@ -303,7 +304,8 @@ function* fetchData(action: FetchAction) {
 		// Indicate fetch action has begun
 		yield put(
 			createAction(action.noStore ? actions.TRANSIENT_FETCH_REQUESTED : actions.FETCH_REQUESTED, {
-				modelName
+				modelName,
+				guid: action.guid
 			})
 		)
 		try {
@@ -359,8 +361,9 @@ function* fetchData(action: FetchAction) {
 					// add by new result's id
 					yield put(
 						createAction(storeAction, {
-							data,
-							modelName: `${modelNameLevels.join('.')}.${data.id}`
+							modelName: `${modelNameLevels.join('.')}.${data.id}`,
+							guid: action.guid,
+							data
 						})
 					)
 					// remove temp item under guid key
@@ -368,8 +371,9 @@ function* fetchData(action: FetchAction) {
 				} else {
 					yield put(
 						createAction(storeAction, {
-							data,
-							modelName
+							modelName,
+							guid: action.guid,
+							data
 						})
 					)
 				}
@@ -389,7 +393,12 @@ function* fetchData(action: FetchAction) {
 		} catch (error) {
 			let errorData = lastFetchError ? lastFetchError.errorData : null
 
-			yield put(createAction(actions.TRY_FETCH_FAILED, _.merge({ modelName }, lastFetchError)))
+			yield put(
+				createAction(
+					actions.TRY_FETCH_FAILED,
+					_.merge({ modelName, guid: action.guid }, lastFetchError)
+				)
+			)
 
 			// Don't do anything with 401 errors
 			// And some errors don't have fetch results associated with them
@@ -410,7 +419,13 @@ function* fetchData(action: FetchAction) {
 		yield put(
 			createAction(
 				action.noStore ? actions.TRANSIENT_FETCH_FAILED : actions.FETCH_FAILED,
-				_.merge({ modelName }, lastFetchError)
+				_.merge(
+					{
+						modelName,
+						guid: action.guid
+					},
+					lastFetchError
+				)
 			)
 		)
 		logger('fetchData retry fail')

--- a/test/fetchSaga.spec.js
+++ b/test/fetchSaga.spec.js
@@ -709,6 +709,7 @@ describe('fetchData', () => {
 				put(
 					createAction(actions.FETCH_RESULT_RECEIVED, {
 						data: { foo: 'bar', guid },
+						guid,
 						modelName: 'test'
 					})
 				)
@@ -1050,6 +1051,7 @@ describe('fetchData', () => {
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
 							data: { id: 2, name: 'bar', guid },
+							guid,
 							modelName: 'entities.2'
 						})
 					)
@@ -1084,7 +1086,8 @@ describe('fetchData', () => {
 				expect(putFetchRequestEffect.value).toEqual(
 					put(
 						createAction(actions.FETCH_REQUESTED, {
-							modelName: `entities.${guid}`
+							modelName: `entities.${guid}`,
+							guid
 						})
 					)
 				)
@@ -1112,6 +1115,7 @@ describe('fetchData', () => {
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
 							data: { id: 3, name: 'baz', guid },
+							guid,
 							modelName: 'entities.3'
 						})
 					)
@@ -1192,6 +1196,7 @@ describe('fetchData', () => {
 					put(
 						createAction(actions.KEY_REMOVAL_REQUESTED, {
 							data: { guid },
+							guid,
 							modelName: 'entities.2'
 						})
 					)
@@ -1243,6 +1248,7 @@ describe('fetchData', () => {
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
 							data: { foo: 'bar', guid },
+							guid,
 							modelName: 'topLevelEntities.2.entityAction'
 						})
 					)
@@ -1399,6 +1405,7 @@ describe('fetchData', () => {
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
 							data: { id: 999, name: 'bar', guid },
+							guid,
 							modelName: 'topLevelEntities.2.secondLevelEntities.999'
 						})
 					)
@@ -1442,7 +1449,8 @@ describe('fetchData', () => {
 				expect(putFetchRequestEffect.value).toEqual(
 					put(
 						createAction(actions.FETCH_REQUESTED, {
-							modelName: `topLevelEntities.1.secondLevelEntities.${guid}`
+							modelName: `topLevelEntities.1.secondLevelEntities.${guid}`,
+							guid
 						})
 					)
 				)
@@ -1471,6 +1479,7 @@ describe('fetchData', () => {
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
 							data: { id: 3, name: 'baz', guid },
+							guid,
 							modelName: 'topLevelEntities.1.secondLevelEntities.3'
 						})
 					)
@@ -1552,6 +1561,7 @@ describe('fetchData', () => {
 					put(
 						createAction(actions.KEY_REMOVAL_REQUESTED, {
 							data: { guid },
+							guid,
 							modelName: 'topLevelEntities.1.secondLevelEntities.2'
 						})
 					)
@@ -1602,6 +1612,7 @@ describe('fetchData', () => {
 					put(
 						createAction(actions.FETCH_RESULT_RECEIVED, {
 							data: { foo: 'bar', guid },
+							guid,
 							modelName: 'topLevelEntities.2.secondLevelEntities.999.entityAction'
 						})
 					)


### PR DESCRIPTION
return `guid` on all resulting actions if it exists in the original action, for easy correlation